### PR TITLE
[Finishes #162528405] Adds endpoint to delete an intervention recored

### DIFF
--- a/app/api/v2/incidents/models.py
+++ b/app/api/v2/incidents/models.py
@@ -188,3 +188,15 @@ class InterventionModel:
         cursor.execute(query)
         conn.commit()
         return 'updated'
+
+    def delete_intervention(self, intervention_id):
+        "Method to delete an intervention record"
+        if self.get_intervention_by_id(intervention_id) == None:
+            return None
+        
+        query = """DELETE FROM incidents WHERE id={0}""".format(intervention_id)
+        conn = self.db
+        cursor = conn.cursor()
+        cursor.execute(query)
+        conn.commit()
+        return 'deleted'

--- a/app/api/v2/incidents/views.py
+++ b/app/api/v2/incidents/views.py
@@ -44,6 +44,25 @@ class Intervention(Resource):
             "data" : incident
         }), 200)
 
+    def delete(self, intervention_id):
+        """method to delete intervention"""
+        delete_status = self.db.delete_intervention(intervention_id)
+
+        if delete_status == None:
+            return make_response(jsonify({
+                "status" : 200,
+                "error" : "Intervention does not exist"
+            }), 200)
+
+        if delete_status == "deleted":
+            return make_response(jsonify({
+                "status" : 200,
+                "data" : {
+                    "id" : intervention_id,
+                    "message" : "Intervention record has been deleted"
+                }
+            }), 200)
+
 class UpdateInterventionStatus(Resource):
     """Class with method for updating an intervention's status"""
 


### PR DESCRIPTION
**What does this PR do?**
Adds an endpoint for deleting an intervention record
**Descriptions of the tasks to be completed?**
Have the following endpoint working
-DELETE  /interventions/1
**How should this be manually tested?**

- After cloning the repo cd into it and flask run
- Using postman on your localhost DELETE http://127.0.0.1:5000/api/v2/interventions/1

**Background context**
A Postgres database should be set up with a user and password
**Pivotal tracker story**
#162528405