### PR TITLE
[Finishes #162668349] Moves badges to the top of README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
+[![Build Status](https://travis-ci.org/Raywire/iReporter.svg?branch=ft-user-endpoins-162357018)](https://travis-ci.org/Raywire/iReporter)
+[![Coverage Status](https://coveralls.io/repos/github/Raywire/iReporter/badge.svg?branch=develop)](https://coveralls.io/github/Raywire/iReporter?branch=develop)
+[![Maintainability](https://api.codeclimate.com/v1/badges/1569388b5eb50371ab82/maintainability)](https://codeclimate.com/github/Raywire/iReporter/maintainability)
+
 Project: iReporter
 Description:iReporter enables any citizen to bring any form of corruption to the notice of appropriate authorities and the
 general public. Users can also report on things that needs government intervention.
 
 GitHub Pages Link: https://raywire.github.io/iReporter/
-
-[![Build Status](https://travis-ci.org/Raywire/iReporter.svg?branch=ft-user-endpoins-162357018)](https://travis-ci.org/Raywire/iReporter)
-[![Coverage Status](https://coveralls.io/repos/github/Raywire/iReporter/badge.svg?branch=develop)](https://coveralls.io/github/Raywire/iReporter?branch=develop)
-[![Maintainability](https://api.codeclimate.com/v1/badges/1569388b5eb50371ab82/maintainability)](https://codeclimate.com/github/Raywire/iReporter/maintainability)
 
 ## Getting Started
 


### PR DESCRIPTION
What does this PR do?
Moves badges to the top of the README file
Descriptions of the tasks to be completed?
Have badges at the top of the README file
How should this be manually tested?
After cloning the repo cd into it and preview the README file on an IDE
Pivotal tracker story
#162668349