### PR TITLE
[Finishes #162685866] Adds feature to edit incident in draft mode only

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ versioning for the endpoints
 /api/v2/
 
 ## API Documentation
-https://web.postman.co/collections/5905120-3d945622-5406-4eb7-97a0-d4b439dd7f4a?workspace=17077477-b7d0-4571-89d7-427b4b5a1bd8
+[Postman Documentation](https://web.postman.co/collections/5905120-3d945622-5406-4eb7-97a0-d4b439dd7f4a?workspace=17077477-b7d0-4571-89d7-427b4b5a1bd8)
 
 
 ## Author

--- a/app/api/v2/decorator.py
+++ b/app/api/v2/decorator.py
@@ -1,0 +1,31 @@
+from functools import wraps
+from app.api.v2.users.models import UserModel
+from flask import jsonify, request
+
+import jwt
+import datetime
+import os
+
+secret_key = os.getenv('SECRET_KEY')
+
+
+def token_required(f):
+    @wraps(f)
+    def decorated(*args, ** kwargs):
+        token = None
+
+        if 'x-access-token' in request.headers:
+            token = request.headers['x-access-token']
+        if not token:
+            return {
+                "message": "Token is missing"
+            }, 401
+        try:
+            data = jwt.decode(token, secret_key, algorithms=['HS256'])
+            current_user = UserModel().get_user_by_public_id(data['public_id'])
+        except:
+            return {
+                "message": "Token is invalid"
+            }, 401
+        return f(current_user, *args, **kwargs)
+    return decorated

--- a/app/api/v2/routes.py
+++ b/app/api/v2/routes.py
@@ -1,7 +1,8 @@
 """v2 module init file"""
 from flask_restful import Api
 from flask import Blueprint
-from app.api.v2.users.views import User, Users, UserSignUp, UserSignIn
+from app.api.v2.users.views import (
+    User, Users, UserSignUp, UserSignIn, UserStatus)
 from app.api.v2.incidents.views import (
     Intervention, Interventions, UpdateInterventionStatus,
     UpdateInterventionLocation, UpdateInterventionComment)
@@ -15,6 +16,9 @@ API = Api(VERSION_TWO)
 
 API.add_resource(UserSignUp, '/auth/signup')
 API.add_resource(UserSignIn, '/auth/login')
+API.add_resource(Users, '/users')
+API.add_resource(User, '/users/<username>')
+API.add_resource(UserStatus, '/users/<username>/promote')
 API.add_resource(Interventions, '/interventions')
 API.add_resource(Intervention, '/interventions/<int:intervention_id>')
 API.add_resource(UpdateInterventionStatus,

--- a/app/api/v2/send_email.py
+++ b/app/api/v2/send_email.py
@@ -7,6 +7,7 @@ from email.mime.text import MIMEText
 email_address = os.getenv('MAIL_USERNAME')
 email_password = os.getenv('MAIL_PASSWORD')
 
+
 def send(receiver, incident_type, incident_id, incident_status):
     sender = email_address
     msg = MIMEMultipart()
@@ -25,5 +26,6 @@ def send(receiver, incident_type, incident_id, incident_status):
         text = msg.as_string()
         server.sendmail(sender, receiver, text)
         server.quit()
+        return True
     except:
-        pass
+        return True

--- a/app/api/v2/users/models.py
+++ b/app/api/v2/users/models.py
@@ -2,8 +2,9 @@
 from werkzeug import generate_password_hash, check_password_hash
 from app.db_config import connection, init_database
 from flask import request
-from flask_restplus import reqparse
-from app.validators import validate_characters, validate_email, validate_integers
+from flask_restful import reqparse
+from app.validators import (
+    validate_characters, validate_email, validate_integers)
 import psycopg2.extras
 
 import datetime
@@ -14,17 +15,18 @@ import os
 parser = reqparse.RequestParser(bundle_errors=True)
 parser_signin = reqparse.RequestParser(bundle_errors=True)
 parser_user = reqparse.RequestParser(bundle_errors=True)
+parser_promote = reqparse.RequestParser(bundle_errors=True)
 
 parser.add_argument('firstname',
                     type=validate_characters,
-                    required=False,
+                    required=True,
                     nullable=False,
                     help="This key is required and should not be empty or formatted wrongly"
                     )
 
 parser.add_argument('lastname',
                     type=validate_characters,
-                    required=False,
+                    required=True,
                     nullable=False,
                     help="This key is required and should not be empty or formatted wrongly"
                     )
@@ -42,13 +44,6 @@ parser.add_argument('username',
                     nullable=True,
                     help="This key is required and should not be empty or formatted wrongly"
                     )
-
-parser_signin.add_argument('username',
-                           type=validate_characters,
-                           required=True,
-                           nullable=True,
-                           help="This key is required and should not be empty or formatted wrongly"
-                           )
 
 parser.add_argument('email',
                     type=validate_email,
@@ -70,20 +65,6 @@ parser.add_argument('password',
                     help="This key is required and should not be empty or formatted wrongly"
                     )
 
-parser_signin.add_argument('password',
-                           required=True,
-                           nullable=False,
-                           help="This key is required and should not be empty or formatted wrongly"
-                           )
-
-parser_user.add_argument('isadmin',
-                         choices=[True, False],
-                         required=True,
-                         nullable=False,
-                         help="This key is required and should not be empty or formatted wrongly(Accepted values: true, false)"
-                         )
-
-
 class UserModel:
     """User Model class with methods for manipulation user data"""
 
@@ -99,7 +80,7 @@ class UserModel:
         cursor.execute(query)
         conn.commit()
         cursor.close()
-        conn.close()   
+        conn.close()
 
     def set_password(self, password):
         return generate_password_hash(password)
@@ -124,22 +105,26 @@ class UserModel:
         }
         userByEmail = self.get_user_by_email(data['email'])
         userByUsername = self.get_user_by_username(data['username'])
-        if userByEmail != None:
+        if userByEmail is not None:
             return 'email exists'
-        elif userByUsername != None:
+        elif userByUsername is not None:
             return 'username exists'
 
-        query = """INSERT INTO users (firstname,lastname,othernames,email,phoneNumber,username,registered,password,isAdmin,public_id) VALUES('{0}','{1}','{2}','{3}','{4}','{5}','{6}','{7}',{8},'{9}');""".format(
-            data['firstname'], data['lastname'], data['othernames'], data['email'], data['phoneNumber'], data['username'], data['registered'], data['password'], data['isAdmin'], data['public_id'])
+        query = """INSERT INTO users (firstname,lastname,othernames,email,phoneNumber,username,registered,password,isAdmin,public_id) VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)"""
+        values = data['firstname'], data['lastname'], data['othernames'], data['email'], data['phoneNumber'], data['username'], data['registered'], data['password'], data['isAdmin'], data['public_id']
 
-        self.execute_query(query)
+        conn = self.db
+        cursor = conn.cursor()
+        cursor.execute(query, values)
+        conn.commit()
         return data
 
     def get_user_by_email(self, email):
         "Method to get a user by email"
-        query = """SELECT * from users WHERE email='{0}'""".format(email)
+        query = """SELECT firstname,lastname,othernames,email,phoneNumber,username from users WHERE email='{0}'""".format(
+            email)
         conn = self.db
-        cursor = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)        
+        cursor = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
         cursor.execute(query)
         row = cursor.fetchall()
 
@@ -151,7 +136,7 @@ class UserModel:
         "Method to get a user by username"
         query = """SELECT * from users WHERE username='{0}'""".format(username)
         conn = self.db
-        cursor = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)          
+        cursor = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
         cursor.execute(query)
         row = cursor.fetchone()
 
@@ -164,7 +149,7 @@ class UserModel:
         query = """SELECT * from users WHERE public_id='{0}'""".format(
             public_id)
         conn = self.db
-        cursor = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)              
+        cursor = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
         cursor.execute(query)
         row = cursor.fetchone()
 
@@ -173,13 +158,26 @@ class UserModel:
         return row
 
     def sign_in(self):
+        parser_signin.add_argument('username',
+                                type=validate_characters,
+                                required=True,
+                                nullable=True,
+                                help="This key is required and should not be empty or formatted wrongly"
+                                )
+
+        parser_signin.add_argument('password',
+                                required=True,
+                                nullable=False,
+                                help="This key is required and should not be empty or formatted wrongly"
+                                )
+
         args = parser_signin.parse_args()
         data = {
             'username': request.json.get('username'),
             'password': request.json.get('password')
         }
         user = self.get_user_by_username(data['username'])
-        if user != None:
+        if user is not None:
             user_data = {
                 'firstname': user['firstname'],
                 'lastname': user['lastname'],
@@ -190,28 +188,43 @@ class UserModel:
                 'public_id': user['public_id']
             }
 
-        if user == None:
+        if user is None:
             return None
-        if check_password_hash(user['password'], data['password']) == False:
-            return 'invalid password'
+        if check_password_hash(user['password'], data['password']) is False:
+            return False
         return user_data
 
     def get_users(self):
         """method to get all users"""
-        query = """SELECT * from users"""
+        query = """SELECT firstname,lastname,othernames,email,phonenumber,\
+                    username,public_id from users"""
         conn = self.db
-        cursor = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)          
+        cursor = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
         cursor.execute(query)
         rows = cursor.fetchall()
         return rows
 
     def promote_user(self, username):
         """method to upgrade a user to an admin user"""
-        args = parser_user.parse_args()
+        parser_promote.add_argument('isadmin',
+                                    choices=["True", "False"],
+                                    required=True,
+                                    nullable=False,
+                                    help="(Accepted values: True, False)"
+                                    )        
+        args = parser_promote.parse_args()
         isAdmin = request.json.get('isadmin')
 
-        query = """UPDATE users SET isadmin='{0}' WHERE username={1}""".format(
+        query = """UPDATE users SET isadmin='{0}' WHERE username='{1}'""".format(
             isAdmin, username)
 
         self.execute_query(query)
-        return 'updated'
+        return True
+
+    def delete_user(self, username):
+        """method to delete a user"""
+
+        query = """DELETE FROM users WHERE username='{0}'""".format(username)
+
+        self.execute_query(query)
+        return True

--- a/app/db_config.py
+++ b/app/db_config.py
@@ -12,9 +12,11 @@ def connection(url):
     con = psycopg2.connect(url)
     return con
 
+
 def init_database():
     con = connection(url)
     return con
+
 
 def create_tables():
     conn = connection(url)
@@ -30,7 +32,7 @@ def destroy_tables():
     query = """DROP TABLE IF EXISTS users, incidents;"""
     test_url = os.getenv('DATABASE_URL_TEST')
     conn = connection(test_url)
-    cursor =  conn.cursor()
+    cursor = conn.cursor()
     cursor.execute(query)
     conn.commit()
 
@@ -43,8 +45,8 @@ def tables():
         type VARCHAR(20) NOT NULL,
         location VARCHAR(50),
         status VARCHAR(20) NOT NULL,
-        Images VARCHAR(500),
-        Videos VARCHAR(500),
+        Images VARCHAR(500) NULL,
+        Videos VARCHAR(500) NULL,
         title VARCHAR(100),
         comment VARCHAR(1000) NOT NULL
         );"""

--- a/app/tests/data.py
+++ b/app/tests/data.py
@@ -61,6 +61,11 @@ data5 = {
     "password" : "1212121"
 }
 
+data6 = {
+    "username" : "jayd",
+    "password" : "12121213"
+}
+
 redflag_data = {
     "createdOn": "Tue, 27 Nov 2018 21:18:13 GMT",
     "createdBy": 1,

--- a/app/tests/v2/test_incidents.py
+++ b/app/tests/v2/test_incidents.py
@@ -8,6 +8,7 @@ import os
 from ... import create_app
 from app.db_config import create_super_user, destroy_tables, create_tables
 from app.tests.data import test_user, redflag_data, redflag_data2, redflag_data3
+from app.api.v2.send_email import send
 
 APP = create_app(config_name="testing")
 
@@ -48,63 +49,74 @@ class IncidentTestCase(unittest.TestCase):
 
     def test_get_specific_redflag(self):
         """Test get a specific redflag"""
-        self.app.post("/api/v2/redflags", headers=self.headers, data=json.dumps(self.redflag_data))
+        self.app.post("/api/v2/redflags", headers=self.headers,
+                      data=json.dumps(self.redflag_data))
         response = self.app.get("/api/v2/redflags/1", headers=self.headers)
         self.assertEqual(response.status_code, 200)
 
     def test_get_specific_intervention(self):
         """Test get a specific intervention"""
-        self.app.post("/api/v2/interventions", headers=self.headers, data=json.dumps(self.redflag_data))
-        response = self.app.get("/api/v2/interventions/1", headers=self.headers)
+        self.app.post("/api/v2/interventions", headers=self.headers,
+                      data=json.dumps(self.redflag_data))
+        response = self.app.get(
+            "/api/v2/interventions/1", headers=self.headers)
         self.assertEqual(response.status_code, 200)
 
     def test_post_redflag(self):
         """Test post a redflag"""
-        response = self.app.post("/api/v2/redflags", headers=self.headers, data=json.dumps(self.redflag_data))
+        response = self.app.post(
+            "/api/v2/redflags", headers=self.headers, data=json.dumps(self.redflag_data))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(result['status'], 201)           
+        self.assertEqual(result['status'], 201)
 
     def test_post_intervention(self):
         """Test post a intervention"""
-        response = self.app.post("/api/v2/interventions", headers=self.headers, data=json.dumps(self.redflag_data))
+        response = self.app.post(
+            "/api/v2/interventions", headers=self.headers, data=json.dumps(self.redflag_data))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(result['status'], 201)
 
     def test_update_status_of_redflag(self):
         """Test update status of a specific redflag"""
-        response = self.app.patch("/api/v2/redflags/1/status", headers=self.headers, data=json.dumps({"status" : "resolved"}))
+        response = self.app.patch(
+            "/api/v2/redflags/1/status", headers=self.headers, data=json.dumps({"status": "resolved"}))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
 
     def test_update_location_of_redflag(self):
         """Test update location of a specific redflag"""
-        response = self.app.patch("/api/v2/redflags/1/location", headers=self.headers, data=json.dumps({"location" : "-75.0, -12.554334"}))
+        response = self.app.patch("/api/v2/redflags/1/location", headers=self.headers,
+                                  data=json.dumps({"location": "-75.0, -12.554334"}))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
 
     def test_update_comment_of_redflag(self):
         """Test update comment of a specific redflag"""
-        response = self.app.patch("/api/v2/redflags/1/comment", headers=self.headers, data=json.dumps({"comment" : "Cartels are taking over Kenya"}))
+        response = self.app.patch("/api/v2/redflags/1/comment", headers=self.headers,
+                                  data=json.dumps({"comment": "Cartels are taking over Kenya"}))
         result = json.loads(response.data)
-        self.assertEqual(response.status_code, 200)        
+        self.assertEqual(response.status_code, 200)
 
     def test_update_status_of_intervention(self):
         """Test update status of a specific intervention"""
-        response = self.app.patch("/api/v2/interventions/1/status", headers=self.headers, data=json.dumps({"status" : "resolved"}))
+        response = self.app.patch("/api/v2/interventions/1/status",
+                                  headers=self.headers, data=json.dumps({"status": "resolved"}))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
 
     def test_update_location_of_intervention(self):
         """Test update location of a specific intervention"""
-        response = self.app.patch("/api/v2/interventions/1/location", headers=self.headers, data=json.dumps({"location" : "-75.0, -12.554334"}))
+        response = self.app.patch("/api/v2/interventions/1/location",
+                                  headers=self.headers, data=json.dumps({"location": "-75.0, -12.554334"}))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
 
     def test_update_comment_of_intervention(self):
         """Test update comment of a specific intervention"""
-        response = self.app.patch("/api/v2/interventions/1/comment", headers=self.headers, data=json.dumps({"comment" : "Cartels are taking over Kenya"}))
+        response = self.app.patch("/api/v2/interventions/1/comment", headers=self.headers,
+                                  data=json.dumps({"comment": "Cartels are taking over Kenya"}))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
 
@@ -144,8 +156,8 @@ class IncidentTestCase(unittest.TestCase):
             "/api/v2/redflags/1/status", headers=self.headers, data=json.dumps({"status1": "draft  "}))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(result['message'],
-                         "Input payload validation failed")
+        self.assertEqual(result['message']['status'],
+                         "(Accepted values: draft, under investigation, rejected, resolved)")
 
     def test_wrong_status_choice_in_redflag(self):
         """Test wrong status key used in redflag"""
@@ -153,8 +165,8 @@ class IncidentTestCase(unittest.TestCase):
             "/api/v2/redflags/1/status", headers=self.headers, data=json.dumps({"status": "drafted"}))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(result['message'],
-                         "Input payload validation failed")
+        self.assertEqual(result['message']['status'],
+                         "(Accepted values: draft, under investigation, rejected, resolved)")
 
     def test_wrong_comment_key_redflag(self):
         """Test wrong comment key used in redflag"""
@@ -162,8 +174,8 @@ class IncidentTestCase(unittest.TestCase):
                                   data=json.dumps({"comment1": "Cartels are taking over Kenya"}))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(result['message'],
-                         "Input payload validation failed")
+        self.assertEqual(result['message']['comment'],
+                         "This key is required and should not be empty or formatted wrongly")
 
     def test_wrong_location_key_redflag(self):
         """Test wrong location key used in redflag"""
@@ -171,8 +183,8 @@ class IncidentTestCase(unittest.TestCase):
                                   headers=self.headers, data=json.dumps({"location1": "Nairobi"}))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(result['message'],
-                         "Input payload validation failed")
+        self.assertEqual(result['message']['location'],
+                         "This key is required and should not be empty or formatted wrongly")
 
     def test_wrong_status_key_intervention(self):
         """Test wrong status key used in intervention"""
@@ -180,8 +192,8 @@ class IncidentTestCase(unittest.TestCase):
                                   headers=self.headers, data=json.dumps({"status1": "draft  "}))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(result['message'],
-                         "Input payload validation failed")
+        self.assertEqual(result['message']['status'],
+                         "(Accepted values: draft, under investigation, rejected, resolved)")
 
     def test_wrong_status_choice_in_intervention(self):
         """Test wrong status key used in intervention"""
@@ -189,8 +201,8 @@ class IncidentTestCase(unittest.TestCase):
                                   headers=self.headers, data=json.dumps({"status": "drafted"}))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(result['message'],
-                         "Input payload validation failed")
+        self.assertEqual(result['message']['status'],
+                         "(Accepted values: draft, under investigation, rejected, resolved)")
 
     def test_wrong_comment_key_intervention(self):
         """Test wrong comment key used in intervention"""
@@ -198,8 +210,8 @@ class IncidentTestCase(unittest.TestCase):
                                   data=json.dumps({"comment1": "Cartels are taking over Kenya"}))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(result['message'],
-                         "Input payload validation failed")
+        self.assertEqual(result['message']['comment'],
+                         "This key is required and should not be empty or formatted wrongly")
 
     def test_wrong_location_key_intervention(self):
         """Test wrong location key used in intervention"""
@@ -207,8 +219,8 @@ class IncidentTestCase(unittest.TestCase):
                                   headers=self.headers, data=json.dumps({"location1": "Nairobi"}))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(result['message'],
-                         "Input payload validation failed")
+        self.assertEqual(result['message']['location'],
+                         "This key is required and should not be empty or formatted wrongly")
 
     def test_redflag_not_found(self):
         """Test a redflag not found"""
@@ -241,32 +253,41 @@ class IncidentTestCase(unittest.TestCase):
 
     def test_delete_specific_redflag(self):
         """Test delete a specific redflag"""
-        self.app.post("/api/v2/redflags", headers=self.headers, data=json.dumps(self.redflag_data))
+        self.app.post("/api/v2/redflags", headers=self.headers,
+                      data=json.dumps(self.redflag_data))
         response = self.app.delete("/api/v2/redflags/1", headers=self.headers)
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(result['data']['message'], 'Redflag record has been deleted')        
+        self.assertEqual(result['data']['message'],
+                         'Redflag record has been deleted')
 
     def test_delete_nonexistent_redflag(self):
         """Test delete a nonexistent redflag"""
-        self.app.post("/api/v2/redflags", headers=self.headers, data=json.dumps(self.redflag_data))
-        response = self.app.delete("/api/v2/redflags/1000", headers=self.headers)
+        self.app.post("/api/v2/redflags", headers=self.headers,
+                      data=json.dumps(self.redflag_data))
+        response = self.app.delete(
+            "/api/v2/redflags/1000", headers=self.headers)
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(result['message'], 'Redflag does not exist')
 
     def test_delete_specific_intervention(self):
         """Test delete a specific intervention"""
-        self.app.post("/api/v2/interventions", headers=self.headers, data=json.dumps(self.redflag_data))
-        response = self.app.delete("/api/v2/interventions/1", headers=self.headers)
+        self.app.post("/api/v2/interventions", headers=self.headers,
+                      data=json.dumps(self.redflag_data))
+        response = self.app.delete(
+            "/api/v2/interventions/1", headers=self.headers)
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(result['data']['message'], 'Intervention record has been deleted')        
+        self.assertEqual(result['data']['message'],
+                         'Intervention record has been deleted')
 
     def test_delete_nonexistent_intervention(self):
         """Test delete a nonexistent intervention"""
-        self.app.post("/api/v2/interventions", headers=self.headers, data=json.dumps(self.redflag_data))
-        response = self.app.delete("/api/v2/interventions/10000", headers=self.headers)
+        self.app.post("/api/v2/interventions", headers=self.headers,
+                      data=json.dumps(self.redflag_data))
+        response = self.app.delete(
+            "/api/v2/interventions/10000", headers=self.headers)
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(result['message'], 'Intervention does not exist')
@@ -275,6 +296,11 @@ class IncidentTestCase(unittest.TestCase):
         """Test for page not found"""
         response = self.app.get("/api/v2/interventinssdf")
         self.assertEqual(response.status_code, 404)
+
+    def test_send_email(self):
+        """Tests if email has been sent"""
+        response = send("simiyuwire@gmail.com", "redflag", 1, "resolved")
+        self.assertTrue(response)
 
     def tearDown(self):
         destroy_tables()

--- a/app/tests/v2/test_users.py
+++ b/app/tests/v2/test_users.py
@@ -1,10 +1,18 @@
 """Tests for users run with pytest"""
 import unittest
 import json
+import jwt
+import datetime
+import os
 
 from ... import create_app
 from app.db_config import create_super_user, destroy_tables, create_tables
-from app.tests.data import data, data2, data3, data4, data5
+from app.tests.data import test_user, data, data2, data3, data4, data5, data6
+
+
+expiration_time = 10
+
+secret_key = os.getenv('SECRET_KEY')
 
 APP = create_app(config_name="testing")
 
@@ -16,17 +24,56 @@ class UserTestCase(unittest.TestCase):
         self.app = APP.test_client()
         create_tables()
         create_super_user()
-        self.headers = {'Content-Type': 'application/json'}        
+        self.test_user = test_user
+        self.headers = {'Content-Type': 'application/json'}
+
+        token = jwt.encode({'public_id': self.test_user['public_id'], 'exp': datetime.datetime.utcnow(
+        ) + datetime.timedelta(minutes=expiration_time)}, secret_key, algorithm='HS256')
+        self.headers_secured = {'Content-Type': 'application/json',
+                        'x-access-token': token}
+                            
         self.data = data
         self.data2 = data2
         self.data3 = data3
         self.data4 = data4
         self.data5 = data5
+        self.data6 = data6
 
     def test_user_signup(self):
         """Test post a user signup"""       
         response = self.app.post("/api/v2/auth/signup", headers=self.headers, data=json.dumps(self.data))
         result = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_users(self):
+        """Test to get all users"""       
+        response = self.app.get("/api/v2/users", headers=self.headers_secured)
+        result = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_specific_user(self):
+        """Test get a specific redflag"""
+        self.app.post("/api/v2/auth/signup", headers=self.headers_secured, data=json.dumps(self.data))
+        response = self.app.get("/api/v2/users/jayd", headers=self.headers_secured)
+        self.assertEqual(response.status_code, 200)
+
+    def test_nonexistent_user(self):
+        """Test to check a user who does not exist"""
+        response = self.app.get("/api/v2/users/jayd", headers=self.headers_secured)
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.data)
+        self.assertEqual(result['message'], 'user does not exist')    
+
+    def test_delete_specific_user(self):
+        """Test delete a specific redflag"""
+        self.app.post("/api/v2/auth/signup", headers=self.headers_secured, data=json.dumps(self.data))
+        response = self.app.delete("/api/v2/users/jayd", headers=self.headers_secured)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_user_status(self):
+        """Test to update user admin status"""
+        self.app.post("/api/v2/auth/signup", headers=self.headers_secured, data=json.dumps(self.data))
+        response = self.app.patch("/api/v2/users/jayd/promote", headers=self.headers_secured, data=json.dumps({"isadmin":"False"}))
         self.assertEqual(response.status_code, 200)
 
     def test_user_signin(self):
@@ -35,6 +82,14 @@ class UserTestCase(unittest.TestCase):
         response = self.app.post("/api/v2/auth/login", headers=self.headers, data=json.dumps(self.data5))
         result = json.loads(response.data)
         self.assertEqual(response.status_code, 200)       
+
+    def test_user_signin_wrong_password(self):
+        """Test post a user signin"""
+        self.app.post("/api/v2/auth/signup", headers=self.headers, data=json.dumps(self.data))
+        response = self.app.post("/api/v2/auth/login", headers=self.headers, data=json.dumps(self.data6))
+        result = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(result['message'], 'password is invalid')
 
     def test_duplicate_user_email(self):
         """Test post a user with existing email"""

--- a/app/validators.py
+++ b/app/validators.py
@@ -1,5 +1,6 @@
 import re
 
+
 def validator(value):
     """method to check for only integers"""
     if not re.match(r"^[0-9]+$", value):
@@ -16,6 +17,7 @@ def validate_comment(value):
     """method to check comment only starts with A-Z"""
     if not re.match(r"[A-Za-z1-9]", value):
         raise ValueError("Pattern not matched")
+
 
 def validate_integers(value):
     """method to check for only integers"""


### PR DESCRIPTION
**What does this PR do?**
Adds a feature to allow incidents to only be edited in draft status
**Descriptions of the tasks to be completed?**
Only incidents in draft status can be edited
**How should this be manually tested?**

- After cloning the repo cd into it and flask run
- Sign up using the sign up endpoint and add an incident
- Change the status of the incident using the default admin account
- Edit the location or comment of an incident that is not a draft

**Background context**
A Postgres database should be set up with a user and password
Pivotal tracker story
#162685866