### PR TITLE
[Finishes #162688143] Fixed editing comment that includes single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pytest --cov=app/
 
 ## Deployment on Heroku
 
-https://enigmatic-inlet-54773.herokuapp.com/api/v2/auth/signup
+[Heroku Application Link](https://enigmatic-inlet-54773.herokuapp.com/api/v2/auth/signup)
 
 ## Built With
 
@@ -91,7 +91,9 @@ versioning for the endpoints
 /api/v2/
 
 ## API Documentation
-[Postman Documentation](https://web.postman.co/collections/5905120-3d945622-5406-4eb7-97a0-d4b439dd7f4a?workspace=17077477-b7d0-4571-89d7-427b4b5a1bd8)
+[Postman Documentation Link](https://web.postman.co/collections/5905120-3d945622-5406-4eb7-97a0-d4b439dd7f4a?workspace=17077477-b7d0-4571-89d7-427b4b5a1bd8)
+
+[Apiary API Documentation](https://ireporter14.docs.apiary.io/#)
 
 
 ## Author

--- a/app/api/v2/incidents/models.py
+++ b/app/api/v2/incidents/models.py
@@ -169,9 +169,12 @@ class IncidentModel:
         if incident['status'] != 'draft':
             return 'not draft'
 
-        query = """UPDATE incidents SET comment='{0}' WHERE id={1}""".format(
-            comment, incident_id)
-        self.execute_query(query)
+        query = """UPDATE incidents SET comment=%s WHERE id=%s"""
+        values = comment, incident_id
+        conn = self.db
+        cursor = conn.cursor()
+        cursor.execute(query, values)
+        conn.commit()
         return True
 
     def delete_incident(self, incident_type, incident_id, current_user_id):

--- a/app/api/v2/incidents/views.py
+++ b/app/api/v2/incidents/views.py
@@ -1,5 +1,5 @@
 """Views for incidents"""
-from flask_restplus import Resource
+from flask_restful import Resource
 from flask import jsonify
 from app.api.v2.incidents.models import IncidentModel
 from app.api.v2.send_email import send

--- a/app/api/v2/users/views.py
+++ b/app/api/v2/users/views.py
@@ -1,5 +1,5 @@
 """Views for users"""
-from flask_restplus import Resource
+from flask_restful import Resource
 from flask import jsonify, request
 from app.api.v2.users.models import UserModel
 from app.api.v2.decorator import token_required


### PR DESCRIPTION
**What does this PR do?**
Fixes bug that crashes the app when a user adds a single quote while updating comment
Descriptions of the tasks to be completed?
Fix issue to allow a user to add a comment that contains a single quotes
**How should this be manually tested?**

- After cloning the repo cd into it and flask run
- Using postman on your localhost try to patch a comment for an incident that includes a single quote

**Background context**
A Postgres database should be set up with a user and password
**Pivotal tracker story**
#162688143