### PR TITLE
[Finishes #162711187] Removes password on sign up data payload

### DIFF
--- a/app/api/v2/users/views.py
+++ b/app/api/v2/users/views.py
@@ -67,12 +67,19 @@ class UserSignUp(Resource):
 
         token = jwt.encode({'public_id': user['public_id'], 'exp': datetime.datetime.utcnow(
         ) + datetime.timedelta(minutes=expiration_time)}, secret_key, algorithm='HS256')
+        user_data = {
+            "name" : user['firstname']+' '+user['lastname'],
+            "usename" : user['username'],
+            "email" : user['email'],
+            "public_id" : user['public_id']
+        }
         return jsonify({
             "status": 201,
+            "message" : "You have been registered successfully",
             "data": [
                 {
                     "token": token.decode('UTF-8'),
-                    "user": user
+                    "user": user_data
                 }
             ]
         })


### PR DESCRIPTION
**What does this PR do?**
Removes password from the signup data payload
**Descriptions of the tasks to be completed?**
When a user signs up the JSON payload should not contain the user's password
**How should this be manually tested?**

- After cloning the repo cd into it and flask run
- Using postman on your localhost sign up a new user and notice the data payload now contains some biodata about the user a success message and a status code 

**Background context**
A Postgres database should be set up with a user and password as per the README file
Pivotal tracker story
#162711187