### PR TITLE
[Finishes #163158837] Adds pagination to red-flags, interventions and users

### DIFF
--- a/UI/admin.html
+++ b/UI/admin.html
@@ -66,10 +66,15 @@
                 fetch(req)
                     .then((response)=>{
                         if(response.ok){
-                          document.getElementById('fa-spin-data').style.display = "none";
+                          try{
+                            document.getElementById('fa-spin-data').style.display = "none";
+                          }catch{}
+                          
                           return response.json();
                         }else{
-                          document.getElementById('fa-spin-data').style.display = "none";
+                          try{
+                            document.getElementById('fa-spin-data').style.display = "none";
+                          }catch{}
                           return response.json();
                         }
                     })
@@ -99,9 +104,19 @@
                               const prevButton = document.getElementById('button_prev');
                               const nextButton = document.getElementById('button_next');
                               const clickPageNumber = document.querySelectorAll('.clickPageNumber');
+                              let perPage = document.getElementById('perPage').value;
                               
                               let current_page = 1;
-                              let records_per_page = 50;                          
+                              let recordsPerPage = parseInt(perPage);
+                              let startNumber = 1;
+                              let totalNumber = users.length;
+
+                              if(recordsPerPage > totalNumber){
+                                recordsPerPage = totalNumber;
+                              }
+                              let endNumber = recordsPerPage;
+                              let virtualEndNumber = recordsPerPage;
+                                                       
                               
                               this.init = function() {
                                   changePage(1);
@@ -145,7 +160,7 @@
                               
                                   result.innerHTML = "";
 
-                                  for(let i = (page -1) * records_per_page; i < (page * records_per_page) && i < user.length; i++) {
+                                  for(let i = (page -1) * recordsPerPage; i < (page * recordsPerPage) && i < user.length; i++) {
 
                                       result.innerHTML += `
                                             <div class="column">
@@ -173,6 +188,10 @@
                                       current_page--;
                                       changePage(current_page);
                                       document.getElementById('current_page').innerHTML = current_page;
+                                      startNumber -= recordsPerPage;
+                                      virtualEndNumber -= recordsPerPage;
+                                      document.getElementById('startNumber').innerHTML = startNumber;
+                                      document.getElementById('endNumber').innerHTML = virtualEndNumber;
                                   }
                               }
 
@@ -181,6 +200,17 @@
                                       current_page++;
                                       changePage(current_page);
                                       document.getElementById('current_page').innerHTML = current_page;
+                                      startNumber += recordsPerPage;
+                                      endNumber += recordsPerPage;
+                                      virtualEndNumber += recordsPerPage;
+                                      if(endNumber > totalNumber){
+                                        endNumber = totalNumber;
+                                      }
+                                      if(endNumber == startNumber){
+                                        
+                                      }
+                                      document.getElementById('startNumber').innerHTML = startNumber;
+                                      document.getElementById('endNumber').innerHTML = endNumber;
                                   } 
                               }
 
@@ -201,8 +231,10 @@
                               }
 
                               let numPages = function() {
-                                return Math.ceil(user.length / records_per_page);  
+                                return Math.ceil(user.length / recordsPerPage);  
                               }
+                              let userNumber = document.getElementById('user_number');
+                              userNumber.innerHTML = `<span id='startNumber'>${startNumber}</span><span id='dash'>-</span><span id='endNumber'>${endNumber}</span> of ${totalNumber}`;
                             } 
                             
                             let pagination = new Pagination();
@@ -241,18 +273,24 @@
                 }
               }
             }
+
+          function perPageSelection(){
+            getData();
+          }
           </script>                                
         </div>  
         <div class="pagination">
           <div class="pagination-block">
-            <!-- <select id='perPage'>
-              <option value="50">50</option>
-              <option value="100">100</option>
-              <option value="250">250</option>
-            </select> -->
+              <span class="per-page">per page:</span>
+            <select id='perPage' onchange="perPageSelection()">
+              <option value="60">60</option>
+              <option value="120">120</option>
+              <option value="300">300</option>
+            </select>
             <span id="page_number" class="outline-none page-number"></span>
             <span class="pageButton outline-none" id="button_prev"><i class="fa fa-chevron-left" aria-hidden="true"></i></span>
             <span class="pageButton outline-none" id="button_next"><i class="fa fa-chevron-right" aria-hidden="true"></i></span>
+            <span id="user_number" class="outline-none page-number"></span>
           </div>
         </div>     
     

--- a/UI/css/styles.css
+++ b/UI/css/styles.css
@@ -759,7 +759,9 @@ p.img-details{
   margin: 0 auto;
   position: relative;
   background-color: white;
-  padding: 10px;
+  padding: 8px;
+  box-shadow: 0 4px 8px 0 rgba(0,0,0,0.4);
+  transition: 0.3s;
 }
 .pagination .tableList {
     /* min-height: 250px; */
@@ -808,4 +810,36 @@ span.pageButton:hover{
 .outline-none {
   outline: none;
   user-select: none; 
+}
+.per-page{
+  color:#737373;
+  /* font-size: 0.9em; */
+}
+.pagination span{
+  font-size: 0.95em;
+}
+select#perPage{
+  -webkit-appearance: none; 
+  -moz-appearance: none;
+  appearance: none; 
+  background-position: 97% center;
+  background-repeat: no-repeat;
+  border: none;
+  outline: none;
+  /* color: #555; */
+  font-size: inherit;
+  margin:0 20px 0 0;
+  padding: 5px 10px;
+}
+select#perPage {
+  outline: none;
+}
+
+select#perPage:focus {
+  outline: none;
+}
+
+select#perPage:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
 }

--- a/UI/interventions.html
+++ b/UI/interventions.html
@@ -92,7 +92,21 @@
             <script>
               getData('intervention', 'all');
               document.getElementById('searchIncidents').addEventListener('keyup', searchIncidents);
-            </script>                                 
+            </script> 
+            <div class="pagination">
+              <div class="pagination-block">
+                  <span class="per-page">per page:</span>
+                <select id='perPage' onchange="perPageSelection('intervention', 'all')">
+                  <option value="60" selected="selected">60</option>
+                  <option value="120">120</option>
+                  <option value="300">300</option>
+                </select>
+                <span id="pageNumber" class="outline-none page-number"></span>
+                <span class="pageButton outline-none" id="button_prev"><i class="fa fa-chevron-left" aria-hidden="true"></i></span>
+                <span class="pageButton outline-none" id="button_next"><i class="fa fa-chevron-right" aria-hidden="true"></i></span>
+                <span id="incident_number" class="outline-none page-number"></span>
+              </div>
+            </div>                                            
           </div>           
           <div class="push"></div>           
       </div>

--- a/UI/js/notifications.js
+++ b/UI/js/notifications.js
@@ -176,14 +176,14 @@ const successNotification = window.createNotification({
     closeOnClick: true,
     showDuration: 3500,
     theme: 'success'
-    });
-    const errorNotification = window.createNotification({
+});
+const errorNotification = window.createNotification({
     closeOnClick: true,
     showDuration: 5000,
     theme: 'error'
-    });
-    const warningNotification = window.createNotification({
+});
+const warningNotification = window.createNotification({
     closeOnClick: true,
     showDuration: 5000,
     theme: 'warning'
-    });
+});

--- a/UI/redflags.html
+++ b/UI/redflags.html
@@ -89,8 +89,23 @@
           <script>
             getData('redflag', 'all');
             document.getElementById('searchIncidents').addEventListener('keyup', searchIncidents);
-          </script>                                  
-        </div> 
+          </script> 
+          <div class="pagination">
+            <div class="pagination-block">
+              <span class="per-page">per page:</span>
+              <select id='perPage' onchange="perPageSelection('redflag', 'all')">
+                <option value="60" selected="selected">60</option>
+                <option value="120">120</option>
+                <option value="300">300</option>
+              </select>
+              <span id="pageNumber" class="outline-none page-number"></span>
+              <span class="pageButton outline-none" id="button_prev"><i class="fa fa-chevron-left" aria-hidden="true"></i></span>
+              <span class="pageButton outline-none" id="button_next"><i class="fa fa-chevron-right" aria-hidden="true"></i></span>
+              <span id="incident_number" class="outline-none page-number"></span>
+            </div>
+            </div>                                          
+          </div> 
+         
         <div class="push"></div>           
     </div>
     <div class="footer">

--- a/UI/view_by_username.html
+++ b/UI/view_by_username.html
@@ -59,8 +59,22 @@
             document.getElementById('searchIncidents').addEventListener('keyup', searchIncidents);
             
             document.getElementById('by-username').innerHTML = 'By' + ' ' +  incident_creator;
-          </script>                                  
-        </div>  
+          </script>
+          <div class="pagination">
+            <div class="pagination-block">
+                <span class="per-page">per page:</span>
+              <select id='perPage' onchange="perPageSelection(incident_type, incident_creator)">
+                <option value="60" selected="selected">60</option>
+                <option value="120">120</option>
+                <option value="300">300</option>
+              </select>
+              <span id="pageNumber" class="outline-none page-number"></span>
+              <span class="pageButton outline-none" id="button_prev"><i class="fa fa-chevron-left" aria-hidden="true"></i></span>
+              <span class="pageButton outline-none" id="button_next"><i class="fa fa-chevron-right" aria-hidden="true"></i></span>
+              <span id="incident_number" class="outline-none page-number"></span>
+            </div>
+          </div>                                       
+        </div> 
         <div class="push"></div>           
       </div>
       <div class="footer">


### PR DESCRIPTION
**What does this PR do?**
Adds pagination to red-flags, interventions and admin user pages
**Descriptions of the tasks to be completed?**
Add select dropdown to select the number of incidents or users per page
Add buttons to scroll to next or previous pages
Display the current page and the range of items per page
**How should this be manually tested?**
Go to https://raywire.github.io/iReporter/UI/interventions.html or https://raywire.github.io/iReporter/UI/redflags.html
The pagination functionality is at the bottom of the page
**Pivotal tracker story**
![screenshot from 2019-01-11 23-04-41](https://user-images.githubusercontent.com/8179091/51056979-5ba19e00-15f5-11e9-8509-8e5412e2d77f.png)
![screenshot from 2019-01-11 23-04-49](https://user-images.githubusercontent.com/8179091/51056981-5c3a3480-15f5-11e9-94f2-69c050e63c0f.png)
![screenshot from 2019-01-11 23-04-56](https://user-images.githubusercontent.com/8179091/51056982-5c3a3480-15f5-11e9-94cb-4e80f1e51b10.png)
#163158837