### PR TITLE
[#163176704] Makes search by username case insensitive

### DIFF
--- a/UI/js/models_incidents.js
+++ b/UI/js/models_incidents.js
@@ -168,7 +168,7 @@ function getData(incident_type, incident_creator, search_data) {
           usernameIncidents = searchedIncidents = incidents;
         } else {
           usernameIncidents = searchedIncidents = incidents.filter(incident => {
-            return incident.title === search_data || incident.id === parseInt(search_data) || incident.username === search_data || incident.status === search_data;
+            return incident.title === search_data || incident.id === parseInt(search_data) || incident.username === search_data.toLowerCase() || incident.status === search_data.toLowerCase();
           })
         }
 

--- a/UI/js/models_users.js
+++ b/UI/js/models_users.js
@@ -51,7 +51,7 @@ function getData(user_data) {
                         } else if (user_data == 'false') {
                             user_data = false
                         }
-                        return user.username === user_data || user.firstname === user_data || user.email === user_data || user.lastname === user_data || user.isadmin === user_data || user.phonenumber === user_data;
+                        return user.username === user_data.toLowerCase() || user.firstname === user_data || user.email === user_data.toLowerCase() || user.lastname === user_data || user.isadmin === user_data.toLowerCase() || user.phonenumber === user_data;
                     })
                 }
 


### PR DESCRIPTION
**What does this PR do?**
Makes search incidents by username case insensitive
**Descriptions of the tasks to be completed?**
A user can search an incident by username in lower or uppercase
**How should this be manually tested?**
Go to https://raywire.github.io/iReporter/UI/interventions.html or https://raywire.github.io/iReporter/UI/redflags.html
Search an incident by username in upper and lower case and notice they both are valid
![screen shot 2019-01-13 at 14 07 50](https://user-images.githubusercontent.com/8179091/51084561-01abf000-173d-11e9-9e13-19298b4ec25e.png)
![screen shot 2019-01-13 at 14 12 13](https://user-images.githubusercontent.com/8179091/51084569-3d46ba00-173d-11e9-80d0-7234a4df9e23.png)


**Pivotal tracker story**
#163176704