### PR TITLE
[Finishes #163435142] Fixes a user's profile data being deleted on incident update

### DIFF
--- a/UI/js/models_incidents.js
+++ b/UI/js/models_incidents.js
@@ -716,7 +716,6 @@ let editLocation = (event, intervention_type, intervention_id) => {
             title: 'Success',
             message: j['data'][0]['message'],
           });
-          localStorage.clear();
           localStorage.setItem('coordinates', location);
         }
       }


### PR DESCRIPTION
**What does this PR do?**
Fixes a bug where a user's profile data is deleted when an incident's location is updated
**Descriptions of the tasks to be completed?**
A user should be able to update the location without clearing their profile data
**How should this be manually tested?**
Go to https://raywire.github.io/iReporter/UI/interventions.html or https://raywire.github.io/iReporter/UI/redflags.html
Pick any incident and update its location, navigate to the profile page and now your profile data is not null
**Pivotal tracker story**
#163435142